### PR TITLE
Fixed URL in "Run on Stedi" button for 214 mapping

### DIFF
--- a/mappings-examples/jedi-214-shopify-fulfillment/README.md
+++ b/mappings-examples/jedi-214-shopify-fulfillment/README.md
@@ -3,4 +3,4 @@
 ## Summary
 This Mapping shows how a 'JEDI 214 Shipment Status Message' can be mapped to a Shopify 'Fulfillment' API shape.
 
-[![Run on Stedi](./../RunOnStedi.svg)](https://terminal.stedi.com/mappings/import?mapping=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214_shopify_fulfillment/mapping.json&source_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214_shopify_fulfillment/source-document.json&target_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214_shopify_fulfillment/target-document.json)
+[![Run on Stedi](./../RunOnStedi.svg)](https://terminal.stedi.com/mappings/import?mapping=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/mapping.json&source_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/jedi-214.json&target_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/shopify-fulfillment.json)


### PR DESCRIPTION
It turns out the casing and a path name was different for the "Run on Stedi" button to work. I fixed the URL references for it, you can check it on the following this link: ["Run on Stedi"](https://terminal.stedi.com/mappings/import?mapping=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/mapping.json&source_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/jedi-214.json&target_json=https://raw.githubusercontent.com/Stedi/starter-kit/main/mappings-examples/jedi-214-shopify-fulfillment/shopify-fulfillment.json)